### PR TITLE
Change company placeholder name to FooClinical

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ export function App(): JSX.Element | null {
       {profile && (
         <Header
           bgColor="#0D9488"
-          title="MyCompany"
+          title="FooClinical"
           onLogo={() => navigate('/')}
           onProfile={() => navigate(`/${getReferenceString(profile)}`)}
           onSignOut={() => {


### PR DESCRIPTION
**Problem:** The display name for the app was 'MyCompany' as a placeholder.
**Solution:** The solution to this is to change the placeholder to 'FooClinical' so that it matches the name of the project and website.
**Start:** The best place to start would be on line line 27 of 'App.tsx'.