### PR TITLE
Add a loading suspense fallback to catch errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { getReferenceString } from '@medplum/core';
 import { ErrorBoundary, Header, useMedplum, Loading } from '@medplum/react';
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { HomePage } from './pages/HomePage';
 import { LandingPage } from './pages/LandingPage';
@@ -35,14 +35,16 @@ export function App(): JSX.Element | null {
         />
       )}
       <ErrorBoundary>
-        <Routes>
-          <Route path="" element={profile ? <HomePage /> : <LandingPage />} />
-          <Route path="/signin" element={<SignInPage />} />
-          <Route path="/profile" element={<ProfilePage />} />
-          <Route path="/:resourceType/:id/:tab" element={<MirrorPage />} />
-          <Route path="/:resourceType/:id" element={<MirrorPage />} />
-          <Route path="/:resourceType" element={<SearchPage />} />
-        </Routes>
+        <Suspense fallback={<Loading />}>
+          <Routes>
+            <Route path="" element={profile ? <HomePage /> : <LandingPage />} />
+            <Route path="/signin" element={<SignInPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/:resourceType/:id/:tab" element={<MirrorPage />} />
+            <Route path="/:resourceType/:id" element={<MirrorPage />} />
+            <Route path="/:resourceType" element={<SearchPage />} />
+          </Routes>
+        </Suspense>
       </ErrorBoundary>
     </>
   );


### PR DESCRIPTION
**Problem:** When going back to the homepage or to many other pages, if the page did not load immediately, it would throw an error since there was no fallback to the loading symbol while the data returned. This made it very difficult to quickly navigate around the website.
**Solution:** A suspense component was added with a loading screen as a fallback while waiting for the main content of the page to load. This gives the user a visual cue if there is a delay in loading so they know that the content is on its way.
**Start:** The best place to start would be on line 38 of `App.tsx`